### PR TITLE
Adding price-rounding functionality

### DIFF
--- a/smart-contracts/Readme.md
+++ b/smart-contracts/Readme.md
@@ -11,3 +11,15 @@ The project is using Buidler & ethers.js (instead of the more common Trufle & we
 - ethers.js: https://docs.ethers.io/v5/getting-started/
 
 To run the tests in the '/test`directory, just run`npm test`(alias for`npx buidler test`). The project uses a local installation of Buidler so you don't need to install it globally. Run`npx buidler help` for more options.
+
+### Bonding Curve
+
+The curve function used is P=log2(S) / 3.321928094887362, which aproximates a base-10 logarithm very closely.
+As solidity has no native support for fixed-point numbers, a library from ABDK Consulting is utilized to enable the required math functionality:
+https://github.com/abdk-consulting/abdk-libraries-solidity/blob/939f0a264f2d07a9e2c7a3a020f0db2c0885dc01/ABDKMath64x64.sol#L8
+
+An excerpt from the linked library:
+
+> Smart contract library of mathematical functions operating with signed 64.64-bit fixed point numbers. Signed 64.64-bit fixed point number is basically a simple fraction whose numerator is signed 128-bit integer and denominator is 2^64. As long as denominator is always the same, there is no need to store it, thus in Solidity signed 64.64-bit fixed point numbers are represented by int128 type holding only the numerator.
+
+The constant value `DENOMINATOR` is simply 2^64, and the constant `CURVE_MODIFER` is the fixed-point representation of the value 3.321928094887362 from our curve function. (3.321928094887362 \* 2^64)

--- a/smart-contracts/contracts/BondingCurveHook.sol
+++ b/smart-contracts/contracts/BondingCurveHook.sol
@@ -56,9 +56,8 @@ contract BondingCurveHook is ILockKeyPurchaseHookV7 {
     bytes calldata data
   ) external view
     returns (uint minKeyPrice)
-  // solium-disable-next-line
   {
-    // no-op.
+    return IPublicLockV7(msg.sender).keyPrice();
   }
 
   /**

--- a/smart-contracts/contracts/BondingCurveHook.sol
+++ b/smart-contracts/contracts/BondingCurveHook.sol
@@ -6,7 +6,7 @@ pragma solidity ^0.5.17;
  * This contract is meant to be registered as a hook,
  * to be called on each key purchase from a Lock contract.
  * It tracks the token(key) supply for the lock, and adjusts
- * the price as the supply grows according to a binary log function.
+ * the price as the supply grows according to a modified binary log function.
  */
 
 import '@unlock-protocol/unlock-abi-7/ILockKeyPurchaseHookV7.sol';
@@ -16,7 +16,7 @@ import 'abdk-libraries-solidity/ABDKMath64x64.sol';
 import '@nomiclabs/buidler/console.sol';
 
 contract BondingCurveHook is ILockKeyPurchaseHookV7 {
-  // @audit add credit for ABDK LIB !!!
+
   // ////////////////////  Libs  ///////////////////////////
 
   using ABDKMath64x64 for int128;
@@ -25,55 +25,26 @@ contract BondingCurveHook is ILockKeyPurchaseHookV7 {
 
   // ////////////////////  Data  ///////////////////////////
 
-  // The number of keys sold using this hook.
+  // Number of keys sold using this hook.
   uint256 public tokenSupply;
 
-  // mainnet address for deploy locked.fyi lock
-  address private constant LOCK_ADDRESS = 0xaad5Bff48e1534EF1f2f0A4184F5C2E61aC47EC3;
+  // Address of paired lock
+  address private lockAddress;
 
-  //@audit for testing only. deploy a mock hook for this
-  address private _testLockAddress;
-
-  /**
-  * 64.64-bit representation of 3.321:
-  * The curve function used is P=log2(S) / 3.321,
-  * which aproximates a base-10 logarithm.
-  * 3.321 * 2^64 = 61261637068789420000
-  * Details on how the fixed-point numbers work here:
-  * https://github.com/abdk-consulting/abdk-libraries-solidity/blob/939f0a264f2d07a9e2c7a3a020f0db2c0885dc01/ABDKMath64x64.sol#L8
-   */
+  // For details: https://github.com/unlock-protocol/locked.fyi/blob/master/smart-contracts/Readme.md
   int128 private constant CURVE_MODIFER = 61278757397652720000;
-
-  //@audit Still needed ???
-  // 2^64, as used by ABDKMath64x64.sol
   int128 private constant DENOMINATOR = 18446744073709552000;
-
-  // ////////////////////  Events  ///////////////////////////
-
-  // what do we want to log here?
-  event KeyPrice(int128 _supply, int128 _price);
 
   // ////////////////////  Functions  ///////////////////////////
 
-  constructor(uint _initialSupply, address _testLock) public {
-    // needed to set supply > 0 (ABDK lib fails otherwise)
+  /// @param _initialSupply The initial value for tokenSupply
+  /// @param _lock The address of the lock configured to use this hook.
+  /// @dev _initialSupply must be > 0 to avoid a revert
+  constructor(uint _initialSupply, address _lock) public {
     tokenSupply = _initialSupply;
-    // @audit testing only, move to mock and remove arg from constructor
-    _testLockAddress = _testLock;
+    lockAddress = _lock;
   }
 
-/**
-   * @notice Used to determine the purchase price before issueing a transaction.
-   * This allows the hook to offer a discount on purchases.
-   * This may revert to prevent a purchase.
-   * param from the msg.sender making the purchase
-   * param recipient the account which will be granted a key
-   * param referrer the account which referred this key sale
-   * param data arbitrary data populated by the front-end which initiated the sale
-   * @return minKeyPrice the minimum value/price required to purchase a key with these settings
-   * @dev the lock's address is the `msg.sender` when this function is called via
-   * the lock's `purchasePriceFor` function
-   */
   function keyPurchasePrice(
     address from,
     address recipient,
@@ -81,12 +52,14 @@ contract BondingCurveHook is ILockKeyPurchaseHookV7 {
     bytes calldata data
   ) external view
     returns (uint minKeyPrice)
+  // solium-disable-next-line
   {
     // no-op.
   }
 
-  // https://ethereum.stackexchange.com/questions/15350/how-to-convert-an-bytes-to-address-in-solidity
+  // Source: https://ethereum.stackexchange.com/questions/15350/how-to-convert-an-bytes-to-address-in-solidity
   function bytesToAddress(bytes memory b) private pure returns (address addr) {
+  // solium-disable-next-line
     assembly {
       addr := mload(add(b,20))
     }
@@ -113,10 +86,7 @@ contract BondingCurveHook is ILockKeyPurchaseHookV7 {
     uint /*pricePaid**/
   ) external
   {
-    // Ensure caller is the locked.fyi lock:
-    // @audit re-enable check before deployment !!!
-    // require(msg.sender == LOCK_ADDRESS);
-    require(msg.sender == _testLockAddress);
+    require(msg.sender == lockAddress, 'UNAUTHORIZED_LOCK');
     IPublicLockV7 lock = IPublicLockV7(msg.sender);
     tokenSupply++;
 
@@ -127,8 +97,6 @@ contract BondingCurveHook is ILockKeyPurchaseHookV7 {
     // get current token address from lock:
     address tokenAddress = lock.tokenAddress();
     lock.updateKeyPricing(keyPrice, tokenAddress);
-    // @audit For testing only ! (adds to gas-usage)
-    // console.logBytes(data);
     address author = bytesToAddress(data);
     console.logAddress(author);
     // DAO.mint(data, 1);

--- a/smart-contracts/contracts/BondingCurveHook.sol
+++ b/smart-contracts/contracts/BondingCurveHook.sol
@@ -57,14 +57,6 @@ contract BondingCurveHook is ILockKeyPurchaseHookV7 {
     // no-op.
   }
 
-  // Source: https://ethereum.stackexchange.com/questions/15350/how-to-convert-an-bytes-to-address-in-solidity
-  function bytesToAddress(bytes memory b) private pure returns (address addr) {
-  // solium-disable-next-line
-    assembly {
-      addr := mload(add(b,20))
-    }
-}
-
   /**
    * @notice If the lock owner has registered an implementer then this hook
    * is called with every key sold.
@@ -96,9 +88,30 @@ contract BondingCurveHook is ILockKeyPurchaseHookV7 {
 
     // get current token address from lock:
     address tokenAddress = lock.tokenAddress();
-    lock.updateKeyPricing(keyPrice, tokenAddress);
+    uint rounded = round(keyPrice);
+    lock.updateKeyPricing(rounded, tokenAddress);
     address author = bytesToAddress(data);
-    console.logAddress(author);
     // DAO.mint(data, 1);
   }
+
+  // ////////////////////  Private  ///////////////////////////
+
+  // Source: https://ethereum.stackexchange.com/questions/15350/how-to-convert-an-bytes-to-address-in-solidity
+  function bytesToAddress(bytes memory b) private pure returns (address addr) {
+  // solium-disable-next-line
+    assembly {
+      addr := mload(add(b,20))
+    }
+  }
+
+   function round(uint n) public pure returns (uint) {
+        uint lower = ((n - 1) / 100000000000000000) * 100000000000000000;
+        uint upper = ((n + 100000000000000000 - 1) / 100000000000000000) * 100000000000000000;
+        uint half = (lower + upper) / 2;
+        if(n < half) {
+            return lower;
+        } else {
+            return upper;
+        }
+    }
 }

--- a/smart-contracts/contracts/BondingCurveHook.sol
+++ b/smart-contracts/contracts/BondingCurveHook.sol
@@ -29,7 +29,7 @@ contract BondingCurveHook is ILockKeyPurchaseHookV7 {
   uint256 public tokenSupply;
 
   // Address of paired lock
-  address private lockAddress;
+  address public lockAddress;
 
   // For details: https://github.com/unlock-protocol/locked.fyi/blob/master/smart-contracts/Readme.md
   int128 private constant CURVE_MODIFER = 61278757397652720000;
@@ -78,7 +78,7 @@ contract BondingCurveHook is ILockKeyPurchaseHookV7 {
     uint /*pricePaid**/
   ) external
   {
-    require(msg.sender == lockAddress, 'UNAUTHORIZED_LOCK');
+    require(msg.sender == lockAddress, 'UNAUTHORIZED_ACCESS');
     IPublicLockV7 lock = IPublicLockV7(msg.sender);
     tokenSupply++;
 

--- a/smart-contracts/package-lock.json
+++ b/smart-contracts/package-lock.json
@@ -652,6 +652,7 @@
         "bignumber.js": "^7.2.0",
         "cbor": "^4.1.5",
         "chalk": "^2.4.1",
+        "ethers": "^4.0.20",
         "glob": "^7.1.3",
         "lodash": "^4.17.15",
         "semver": "^5.5.1",
@@ -668,10 +669,55 @@
           "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.47.tgz",
           "integrity": "sha512-yzBInQFhdY8kaZmqoL2+3U5dSTMrKaYcb561VU+lDzAYvqt+2lojvBEy+hmpSNuXnPTx7m9+04CzWYOUqWME2A=="
         },
+        "ethers": {
+          "version": "4.0.47",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.47.tgz",
+          "integrity": "sha512-hssRYhngV4hiDNeZmVU/k5/E8xmLG8UpcNUzg6mb7lqhgpFPH/t7nuv20RjRrEf0gblzvi2XwR5Te+V3ZFc9pQ==",
+          "requires": {
+            "aes-js": "3.0.0",
+            "bn.js": "^4.4.0",
+            "elliptic": "6.5.2",
+            "hash.js": "1.1.3",
+            "js-sha3": "0.5.7",
+            "scrypt-js": "2.0.4",
+            "setimmediate": "1.0.4",
+            "uuid": "2.0.1",
+            "xmlhttprequest": "1.8.0"
+          }
+        },
+        "hash.js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "js-sha3": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+        },
+        "scrypt-js": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
+          "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw=="
+        },
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
           "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        },
+        "setimmediate": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
+          "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48="
+        },
+        "uuid": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
         },
         "web3": {
           "version": "1.2.2",
@@ -729,6 +775,7 @@
         "@truffle/interface-adapter": "^0.4.6",
         "bignumber.js": "^7.2.1",
         "ethereum-ens": "^0.8.0",
+        "ethers": "^4.0.0-beta.1",
         "exorcist": "^1.0.1",
         "source-map-support": "^0.5.16",
         "web3": "1.2.1",
@@ -753,6 +800,7 @@
           "integrity": "sha512-2dYccf7lAwx90NVYmn89QABpd3dx7BxvDAaHgzVa2YVOUkTUpkZiaIsD2YlsVQ1rew17wMNi5WXH2RFnmzQ82A==",
           "requires": {
             "bn.js": "^4.11.8",
+            "ethers": "^4.0.32",
             "source-map-support": "^0.5.19",
             "web3": "1.2.1"
           }
@@ -799,6 +847,29 @@
             "bn.js": "^4.11.6",
             "elliptic": "^6.4.0",
             "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "ethers": {
+          "version": "4.0.47",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.47.tgz",
+          "integrity": "sha512-hssRYhngV4hiDNeZmVU/k5/E8xmLG8UpcNUzg6mb7lqhgpFPH/t7nuv20RjRrEf0gblzvi2XwR5Te+V3ZFc9pQ==",
+          "requires": {
+            "aes-js": "3.0.0",
+            "bn.js": "^4.4.0",
+            "elliptic": "6.5.2",
+            "hash.js": "1.1.3",
+            "js-sha3": "0.5.7",
+            "scrypt-js": "2.0.4",
+            "setimmediate": "1.0.4",
+            "uuid": "2.0.1",
+            "xmlhttprequest": "1.8.0"
+          },
+          "dependencies": {
+            "scrypt-js": {
+              "version": "2.0.4",
+              "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
+              "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw=="
+            }
           }
         },
         "get-stream": {

--- a/smart-contracts/test/hook.js
+++ b/smart-contracts/test/hook.js
@@ -283,6 +283,8 @@ describe('Price Rounding', () => {
     const s = 35
     purchaseHook = await deployHook(s, lockedFyiLock.address)
     await lockedFyiLock.setEventHooks(purchaseHook.address, ZERO_ADDRESS)
+    const hookAddr = await lockedFyiLock.onKeyPurchaseHook()
+    assert.equal(hookAddr, purchaseHook.address)
     await lockedFyiLock.addLockManager(purchaseHook.address)
     const keyPurchaserAddress = await keyPurchaser.getAddress()
     const keyPriceBefore = await lockedFyiLock.keyPrice()
@@ -410,7 +412,8 @@ describe('Price Rounding', () => {
 })
 
 describe('Security', () => {
-  it.skip('Should fail if anyone but the lock calls onKeyPurchase', async function () {
+  // this should fail !
+  it('Should fail if anyone but the lock calls onKeyPurchase', async function () {
     const [wallet, addr1, author] = await ethers.getSigners()
     const address1 = await addr1.getAddress()
     const authorAddress = await author.getAddress()

--- a/smart-contracts/test/setup.js
+++ b/smart-contracts/test/setup.js
@@ -16,13 +16,14 @@ const provider = ethers.provider
 let hook_Address
 
 exports.deployToken = async () => {
-  const [wallet, addr1, addr2] = await ethers.getSigners()
+  const [wallet, addr1, addr2, addr3] = await ethers.getSigners()
   const Token = await ethers.getContractFactory('TestToken', wallet)
   const token = await Token.deploy()
   await token.deployed()
   const walletAddress = await wallet.getAddress()
   const address1 = await addr1.getAddress()
   const address2 = await addr2.getAddress()
+  const address3 = await addr3.getAddress()
   await token.initialize(walletAddress)
   await token.mint(
     walletAddress,
@@ -30,6 +31,7 @@ exports.deployToken = async () => {
   )
   await token.mint(address1, BigNumber.from(1000).mul('1000000000000000000'))
   await token.mint(address2, BigNumber.from(1000).mul('1000000000000000000'))
+  await token.mint(address3, BigNumber.from(1000).mul('1000000000000000000'))
   console.log(`Test ERC20-token deployed at: ${token.address}`)
   return token
 }


### PR DESCRIPTION
Rounds the price to the nearest 1/10 of 1 Dai. 
**eg:**
while s=29 - 35, p= 1.500000000000000000 // unrounded = 1.53148...
while s=36 - 44, p= 1.600000000000000000 // unrounded = 1.55630

Also cleans up some comments and unneeded stuff from the contract.

The last remaining addition to the contract (apart from possible gas-optimizations) is to add the call to the DAO contract to initiate minting an FYI token for the author.

Next steps are:
3.) take a closer look at how to get the DAO to do what we need it to do
4.) add the call to the DAO in the hook
5.) deploy rinkeby test system

Note on gas:
Base case (No hook) for purchase:
values are: Min, Max, Average, # of calls, cost $

![IMAGE](quiver-image-url/BAFB1CBD1EB78D39C9924213036A0A47.jpg =1522x57)
![image](https://user-images.githubusercontent.com/17053076/86366699-547ead80-bc38-11ea-86d7-c777c9b955c1.png)

With the hook:
No price update:    199358 gas for a first key, 109577 gas for a key extension
With price update: 225561 gas for a first key, 135768 gas for a key extension

So, around 26,000 extra gas for updating the price (which we're doing far less often now).
For reference, it costs:
- 21000 gas to send eth 
- 20000 gas to write to storage the first time( 5000 to update it afterwards)

Overall, even for our worst-case scenario(first time key purchase with a price update), we're well below the max values for the purchase function _without_ even using the hook!
